### PR TITLE
Fix useStore types for usage with MapStore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export interface UseStoreOptions<
  */
 export function useStore<
   SomeStore extends Store,
-  Key extends keyof StoreValue<Store>
+  Key extends keyof StoreValue<SomeStore>
 >(
   store: SomeStore,
   options?: UseStoreOptions<SomeStore, Key>


### PR DESCRIPTION
`Key extends keyof StoreValue<Store>` infers to
`string | number | symbol`, but we want keys of the given object