### PR TITLE
Support union types in `useStore`

### DIFF
--- a/errors.ts
+++ b/errors.ts
@@ -1,0 +1,26 @@
+import { map } from 'nanostores'
+import { useStore } from './index'
+
+type TestType =
+  | { id: string; isLoading: true }
+  | { isLoading: false; a: string; b: number; c?: number }
+
+let test = map<TestType>()
+
+let testValue = useStore(test)
+if (!testValue.isLoading) {
+  testValue.b
+}
+
+// THROWS Property 'a' does not exist on type 'TestType'.
+testValue.a
+
+let testValueSlice = useStore(test, { keys: ['isLoading', 'a'] })
+if (!testValueSlice.isLoading) {
+  testValueSlice.a
+  // The rest of the error is skipped, because order of properties varies
+  // THROWS Property 'b' does not exist on type 'Pick<TestType,
+  testValueSlice.b
+}
+
+testValueSlice.a

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,8 @@
 import { MapStore, Store, StoreValue } from 'nanostores'
 
-export interface UseStoreOptions<
-  SomeStore,
-  Key extends string | number | symbol
-> {
+type AllKeys<T> = T extends any ? keyof T : never
+
+export interface UseStoreOptions<SomeStore, Key extends PropertyKey> {
   keys?: SomeStore extends MapStore ? Key[] : never
 }
 
@@ -19,7 +18,7 @@ export interface UseStoreOptions<
  *
  * export const Layout = () => {
  *   let page = useStore(router)
- *   if (page.router === 'home') {
+ *   if (page.route === 'home') {
  *     return <HomePage />
  *   } else {
  *     return <Error404 />
@@ -30,9 +29,38 @@ export interface UseStoreOptions<
  * @param store Store instance.
  * @returns Store value.
  */
+export function useStore<SomeStore extends Store>(
+  store: SomeStore
+): StoreValue<SomeStore>
+
+/**
+ * Subscribe to store changes and get store’s value.
+ *
+ * Can be user with store builder too.
+ *
+ * ```js
+ * import { useStore } from 'nanostores/react'
+ *
+ * import { router } from '../store/router'
+ *
+ * export const Layout = () => {
+ *   let page = useStore(router, { keys: [ 'route' ] })
+ *   if (page.route === 'home') {
+ *     return <HomePage />
+ *   } else {
+ *     return <Error404 />
+ *   }
+ * }
+ * ```
+ *
+ * @param store Store instance.
+ * @param options Subscription configuration.
+ *     `keys` attribute controls which store value properties will be returned and listened to.
+ * @returns Store value.
+ */
 export function useStore<
   SomeStore extends Store,
-  Key extends keyof StoreValue<SomeStore>
+  Key extends AllKeys<StoreValue<SomeStore>>
 >(
   store: SomeStore,
   options?: UseStoreOptions<SomeStore, Key>

--- a/package.json
+++ b/package.json
@@ -126,6 +126,9 @@
       "jsdom": false
     }
   },
+  "eslintIgnore": [
+    "**/errors.ts"
+  ],
   "size-limit": [
     {
       "import": {


### PR DESCRIPTION
 - [x] Fix typo in docs
 - [x] Allow all keys for union types
 - [x] If options are not provided return simple value, otherwise return value subset (For this I used function declaration overloading, not sure this is the only way though)