### PR TITLE
Update type signature for useStore key property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,13 @@
-import { MapStore, Store, StoreValue } from 'nanostores'
+import { Store, StoreValue } from 'nanostores'
 
 type AllKeys<T> = T extends any ? keyof T : never
 
-export interface UseStoreOptions<SomeStore, Key extends PropertyKey> {
-  keys?: SomeStore extends MapStore ? Key[] : never
+type StoreKeys<T> = T extends { setKey: (k: infer K, v: any) => unknown }
+  ? K
+  : never
+
+export interface UseStoreOptions<SomeStore> {
+  keys?: StoreKeys<SomeStore>[]
 }
 
 /**
@@ -58,15 +62,11 @@ export function useStore<SomeStore extends Store>(
  *     `keys` attribute controls which store value properties will be returned and listened to.
  * @returns Store value.
  */
-export function useStore<
-  SomeStore extends Store,
-  Key extends AllKeys<StoreValue<SomeStore>>
->(
+export function useStore<SomeStore extends Store>(
   store: SomeStore,
-  options?: UseStoreOptions<SomeStore, Key>
-): SomeStore extends MapStore
-  ? Pick<StoreValue<SomeStore>, Key>
-  : StoreValue<SomeStore>
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  options?: UseStoreOptions<SomeStore>
+): StoreValue<SomeStore>
 
 /**
  * Batch React updates. It is just wrap for React’s `unstable_batchedUpdates`

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -1,4 +1,4 @@
-import { map } from 'nanostores'
+import { map, WritableAtom } from 'nanostores'
 import { useStore } from '..'
 
 type TestType =
@@ -18,9 +18,23 @@ testValue.a
 let testValueSlice = useStore(test, { keys: ['isLoading', 'a'] })
 if (!testValueSlice.isLoading) {
   testValueSlice.a
-  // The rest of the error is skipped, because order of properties varies
-  // THROWS Property 'b' does not exist on type 'Pick<TestType,
   testValueSlice.b
 }
+if (testValueSlice.isLoading) {
+  testValueSlice.id
+  // THROWS Property 'a' does not exist on type
+  testValueSlice.a
+}
 
+// THROWS Property 'a' does not exist on type 'TestType'.
 testValueSlice.a
+
+declare const customStore: WritableAtom<TestType> & {
+  setKey: (key: 'hey' | 'there', value: unknown) => void
+}
+{
+  // THROWS Type '"does-not-exist"' is not assignable
+  useStore(customStore, { keys: ['does-not-exist'] })
+
+  let testValueSlice = useStore(customStore, { keys: ['hey', 'there'] })
+}


### PR DESCRIPTION
Updated the signature for `useStore` to be more correct in terms of fetching the possible key values. Instead of looking at store value and using `keyof` on it we now look at what keys `setKey` function accepts. It's actually more aligned with the way `listenKeys` is implemented.

Mostly, that will be helpful for the upcoming [`deepMap` implementation](https://github.com/nanostores/nanostores/pull/161) in the nanostores core.

Also, I fixed a strange assumption in the signature. I commented it in the code to simplify the review.