### PR TITLE
remove useSyncExternalStore

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import { listenKeys } from 'nanostores'
-import { useCallback } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useCallback, useSyncExternalStore } from 'react'
 
 export function useStore(store, opts = {}) {
   let sub = useCallback(

--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
       "url": "https://github.com/sponsors/ai"
     }
   ],
-  "dependencies": {
-    "use-sync-external-store": "^1.2.0"
-  },
   "peerDependencies": {
     "nanostores": "^0.8.0",
     "react": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,5 @@
 lockfileVersion: '6.0'
 
-dependencies:
-  use-sync-external-store:
-    specifier: ^1.2.0
-    version: 1.2.0(react@18.2.0)
-
 devDependencies:
   '@logux/eslint-config':
     specifier: ^49.0.0
@@ -2193,6 +2188,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2250,6 +2246,7 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: true
 
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -2491,6 +2488,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: true
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -2821,14 +2819,6 @@ packages:
     dependencies:
       punycode: 2.3.0
     dev: true
-
-  /use-sync-external-store@1.2.0(react@18.2.0):
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}


### PR DESCRIPTION
According to `package.json`, the package requires `react>=18.0.0`. At the same time, a shim from `use-sync-external-store` package is used. However, when used together with React 18, it doesn't do anything at all; it simply uses a hook from React itself. Therefore, you can use `useSyncExternalStore` directly.

Now the package size is around 223 bytes (minified). A couple of kilobytes of the shim are now not included in the bundle.

I'm not sure exactly how you measure package sizes, so I didn't update the information in the README.

Closed https://github.com/nanostores/react/issues/14 

