### PR TITLE
Reverting value getter for the hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ export function useStore(store, opts = {}) {
     [opts.keys, store]
   )
 
-  let get = useCallback(() => store.value, [store])
+  let get = store.get.bind(store)
 
   return useSyncExternalStore(subscribe, get, get)
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
 import type { FC, ReactNode } from 'react'
 
 import './setup.js'
-import { STORE_UNMOUNT_DELAY, onMount, atom, map, onStop } from 'nanostores'
+import { STORE_UNMOUNT_DELAY, onMount, atom, map, computed } from 'nanostores'
 import { render, act, screen } from '@testing-library/react'
 import { equal, is } from 'uvu/assert'
 import { delay } from 'nanodelay'
@@ -212,21 +212,19 @@ test('handles keys option', async () => {
   equal(renderCount, 4)
 })
 
-test('calling useStore does not cause onStop', async () => {
-  let letter = atom('a')
+test('works with stores that set their values in lifecycle hooks', async () => {
+  let $1 = atom(1)
+  let $2 = atom(1)
 
-  let wasStopCalled = false
-  onStop(letter, () => {
-    wasStopCalled = true
-  });
+  let $c = computed([$1, $2], (a, b) => a + b)
 
   let Test: FC = () => {
-    let value = useStore(letter)
+    let value = useStore($c)
+    if (value !== 2) throw new Error()
     return h('div', null, value)
   }
 
   render(h(Test))
-  is(wasStopCalled, false)
 })
 
 test.run()


### PR DESCRIPTION
Reverting the 0.7 version change that breaks the lifecycle guarantees. `useSyncExternalStore` has a bit of an odd mechanic, it calls stuff multiple times, and always starts with the provided `.get()`. Hence, first time we get a render we won't have any value in `store.value`, and that's mission critical for all stores that utilize lifecycles (`onStart`, `onMount`) for setting initial values.

Added a very simple test case for using a `computed` store (previous implementation failed it).