### PR TITLE
ListenKeys - forgive using string instead of array

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ export function useStore(store, opts = {}) {
   let subscribe = useCallback(
     onChange =>
       opts.keys
-        ? listenKeys(store, opts.keys, onChange)
+        ? listenKeys(store, Array.isArray(opts.keys) ? opts.keys : [opts.keys], onChange)
         : store.listen(onChange),
     [opts.keys, store]
   )


### PR DESCRIPTION
When you forget to wrap keys in an array, the listener will not update. This is a bit more forgiving.

Example:
```
const store = useStore($store, {keys: 'notAnArray'})
```
