### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ with many atomic tree-shakable stores.
 - It has good **TypeScript** support.
 
 ```tsx
-import { useStore } from '@nanostores/react'
+import { useStore } from '@nanostores/react';
+import { $profile } from '../stores/profile.js';
 
-import { profile } from '../stores/profile.js'
-
-export const Header = () => {
-  const { userId } = useStore(profile)
-  return <header>{currentUser.name}</header>
+export const Header = ({ postId }) => {
+  const profile = useStore($profile);
+  return <header>Hi, {profile.name}</header>
 }
 ```
 


### PR DESCRIPTION
The example in the readme is not correct. I've copied the example from the main nanostores readme.