### PR TITLE
fix: cache snapshot & add option `deps`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import type { Store, StoreValue } from 'nanostores'
+import type { DependencyList } from 'react'
 
 type StoreKeys<T> = T extends { setKey: (k: infer K, v: any) => unknown }
   ? K
@@ -9,6 +10,13 @@ export interface UseStoreOptions<SomeStore> {
    * Will re-render components only on specific key changes.
    */
   keys?: StoreKeys<SomeStore>[]
+  /**
+   * @default
+   * ```ts
+   * [store, options.keys]
+   * ```
+   */
+  deps?: DependencyList
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "index.js": "{ useStore }",
         "nanostores": "{ map, computed }"
       },
-      "limit": "871 B"
+      "limit": "901 B"
     }
   ]
 }


### PR DESCRIPTION
fix #22

Adding the deps option is to allow users to manually control whether to detect changes in the keys (references), saving the trouble of using useMemo. This might be a better default behavior, but it could introduce a breaking change.