### PR TITLE
Update react peer dependency to allow for >=18.0.0 || 19.0.0-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "peerDependencies": {
     "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0",
-    "react": ">=18.0.0"
+    "react": ">=19.0.0"
   },
   "devDependencies": {
     "@logux/eslint-config": "^53.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "peerDependencies": {
     "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0",
-    "react": ">=19.0.0"
+    "react": ">=18.0.0 || 19.0.0-rc"
   },
   "devDependencies": {
     "@logux/eslint-config": "^53.4.0",


### PR DESCRIPTION
`next.js` uses react 19 release candidate for its app router functionality.
Thus to allow for react 19 release candidate versions, I added ` || 19.0.0-rc` without breaking the users using react 18.