### PR TITLE
added >= for React 19 peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "peerDependencies": {
     "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0",
-    "react": ">=18.0.0 || 19.0.0-rc"
+    "react": ">=18.0.0 || >=19.0.0-rc"
   },
   "devDependencies": {
     "@logux/eslint-config": "^53.5.1",


### PR DESCRIPTION
Unfortunately the `|| 19.0.0-rc` was not sufficient. I changed it to `|| >=19.0.0-rc`. This works, as I have actually tested it:

```
amin@tux ~/dev/test/react $ ls
CHANGELOG.md  eslint.config.js  index.d.ts  index.js  LICENSE  package.json  pnpm-lock.yaml  README.md  test  tsconfig.json
amin@tux ~/dev/test/react $ cat package.json | grep -A3 peerDependencies
  "peerDependencies": {
    "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0",
    "react": ">=18.0.0 || >=19.0.0-rc"
  },
amin@tux ~/dev/test/react $ npm pack
npm notice
npm notice 📦  @nanostores/react@0.8.1
npm notice Tarball Contents
npm notice 147B .editorconfig
npm notice 11B .github/FUNDING.yml
npm notice 1.4kB .github/workflows/release.yml
npm notice 1.3kB .github/workflows/test.yml
npm notice 1.1kB CHANGELOG.md
npm notice 1.1kB LICENSE
npm notice 1.2kB README.md
npm notice 364B eslint.config.js
npm notice 1.0kB index.d.ts
npm notice 630B index.js
npm notice 2.3kB package.json
npm notice Tarball Details
npm notice name: @nanostores/react
npm notice version: 0.8.1
npm notice filename: nanostores-react-0.8.1.tgz
npm notice package size: 4.7 kB
npm notice unpacked size: 10.5 kB
npm notice shasum: 66e6b50926f57e15134837b6c71f51ce4ee69ef7
npm notice integrity: sha512-2BGd5SBVio2F6[...]NfbqXxeohwlSg==
npm notice total files: 11
npm notice
nanostores-react-0.8.1.tgz
amin@tux ~/dev/test/react $ cd ..
amin@tux ~/dev/test $ npx create-next-app@latest
✔ What is your project named? … my-app
✔ Would you like to use TypeScript? … No / Yes
✔ Would you like to use ESLint? … No / Yes
✔ Would you like to use Tailwind CSS? … No / Yes
✔ Would you like your code inside a `src/` directory? … No / Yes
✔ Would you like to use App Router? (recommended) … No / Yes
✔ Would you like to use Turbopack for next dev? … No / Yes
✔ Would you like to customize the import alias (@/* by default)? … No / Yes
Creating a new Next.js app in /home/amin/dev/test/my-app.

Using npm.

Initializing project with template: app-tw


Installing dependencies:
- react
- react-dom
- next

Installing devDependencies:
- typescript
- @types/node
- @types/react
- @types/react-dom
- postcss
- tailwindcss
- eslint
- eslint-config-next

npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated @humanwhocodes/config-array@0.13.0: Use @eslint/config-array instead
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.

added 372 packages, and audited 373 packages in 12s

138 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Initialized a git repository.

Success! Created my-app at /home/amin/dev/test/my-app

amin@tux ~/dev/test $ cd my-app/
amin@tux ~/dev/test/my-app $ npm install ../react/nanostores-react-0.8.1.tgz

added 5 packages, and audited 378 packages in 1s

142 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
amin@tux ~/dev/test/my-app $
```