### PR TITLE
Deepmap support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import { listenKeys } from 'nanostores'
 import { useCallback, useRef, useSyncExternalStore } from 'react'
 
 let emit = (snapshotRef, onChange) => value => {
@@ -18,9 +17,16 @@ export function useStore(store, { keys, deps = [store, keys], ssr } = {}) {
   let subscribe = useCallback(onChange => {
     emit(snapshotRef, onChange)(store.value)
 
-    return keys?.length > 0
-      ? listenKeys(store, keys, emit(snapshotRef, onChange))
-      : store.listen(emit(snapshotRef, onChange))
+    if (keys && keys.length > 0) {
+      let keysSet = new Set(keys).add(undefined)
+      return store.listen((value, _, changed) => {
+        let baseKey = changed ? changed.split(/\.|\[/)[0] : undefined
+        if (keysSet.has(changed) || keysSet.has(baseKey)) {
+          emit(snapshotRef, onChange)(value)
+        }
+      })
+    }
+    return store.listen(emit(snapshotRef, onChange))
   }, deps)
 
   let get = () => snapshotRef.current

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanostores/react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React integration for Nano Stores, a tiny state manager with many atomic tree-shakable stores",
   "keywords": [
     "react",
@@ -65,7 +65,7 @@
         "index.js": "{ useStore }",
         "nanostores": "{ map, computed }"
       },
-      "limit": "958 B"
+      "limit": "977 B"
     }
   ],
   "engines": {


### PR DESCRIPTION
# Deepmap Reactivity Support
## The Problem
When using `@nanostores/deepmap`, if a component observes a parent key, it fails to **re-render** when a deeply nested child mutates.
```ts
type SomeStore = {
  a?: {
    ab?: {
      count?: number;
    };
  }
};

// BEFORE: Reactivity required exact path matching
// Mutating "a.ab.count" wouldn't trigger a re-render
const { a } = useStore($globalStore, { keys: ["a"] }); // No reactivity
```
In a tree object, components need to be able to watch a parent branch and react to any changes inside it.

## The Solution
Replaced the strict `listenKeys` for inline listener. Now the hook extracts the base key from the mutated path and evaluates if the branch has been affected.
```ts
// AFTER: Observing a parent key now correctly reacts to any nested child mutations
const { a } = useStore($globalStore, { keys: ["a"] }); // Reactivity in "a"
```
## Arquitecture Doubts
I considered two approaches for this implementation:

 - Inline support in useStore (Chosen): By integrating the base-key validation directly into the existing hook, we seamlessly support atom, map, and deepMap in a single unified API.

 - Create a separate `useDeepStore` hook: This would require duplicating the entire `useStore` logic, which would negatively impact the bundle size.

**Bundle impact**: Modifying the existing hook inline is significantly more optimized, adding ~19 bytes less to the final bundle size compared to copy-pasting same logic into a separate `useDeepStore` hook.